### PR TITLE
Initial migration of GH action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,5 @@
 name: Build bs-platform-js
-on:
-  push:
-    tags:
-    - '*'
+on: [push]
 jobs:
   run:
     name: Build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,9 +19,8 @@ jobs:
       - name: Checkout BuckleScript repo
         uses: actions/checkout@v2
         with:
-          repository: jchavarri/bucklescript # temporary, until https://github.com/BuckleScript/bucklescript/pull/4395 is merged
+          repository: bucklescript/bucklescript
           path: bucklescript
-          ref: 'fix-jsoo-remt' # temporary, until https://github.com/BuckleScript/bucklescript/pull/4395 is merged
 
       - run: git submodule update --init && ./scripts/buildocaml.js
         working-directory: bucklescript

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,49 @@
+name: Build bs-platform-js
+on:
+  push:
+    tags:
+    - '*'
+jobs:
+  run:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ocaml-version: ["4.06.1"]
+        node-version: [12.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Checkout BuckleScript repo
+        uses: actions/checkout@v2
+        with:
+          repository: BuckleScript/bucklescript
+          path: bucklescript
+
+      - run: git submodule update --init && ./scripts/buildocaml.js
+        working-directory: bucklescript
+
+      - run: ./scripts/ninja.js config && ./scripts/ninja.js build
+        working-directory: bucklescript
+
+      - run: mkdir playground && mkdir playground/stdlib
+        working-directory: bucklescript
+
+      - run: BS_PLAYGROUND=../../main/bundle ./scripts/repl.js -prepublish
+        working-directory: bucklescript
+
+      - name: Test — print Sys.ocaml_version
+        run: node -e "require('./exports.js'); eval(ocaml.compile('Js.log Sys.ocaml_version').js_code)"
+        working-directory: main/bundle
+
+      - name: Archive npm artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: bs-platform-js
+          path: main
+

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,8 +19,9 @@ jobs:
       - name: Checkout BuckleScript repo
         uses: actions/checkout@v2
         with:
-          repository: BuckleScript/bucklescript
+          repository: jchavarri/bucklescript # temporary, until https://github.com/BuckleScript/bucklescript/pull/4395 is merged
           path: bucklescript
+          ref: 'fix-jsoo-remt' # temporary, until https://github.com/BuckleScript/bucklescript/pull/4395 is merged
 
       - run: git submodule update --init && ./scripts/buildocaml.js
         working-directory: bucklescript

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,11 @@
 name: Build bs-platform-js
-on: [push]
+on:
+  push:
+    branches:
+      - '*'
+  schedule:
+    - cron: '* 0 * * *' # every day at midnight utc
+
 jobs:
   run:
     name: Build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,9 +28,6 @@ jobs:
       - run: ./scripts/ninja.js config && ./scripts/ninja.js build
         working-directory: bucklescript
 
-      - run: mkdir playground && mkdir playground/stdlib
-        working-directory: bucklescript
-
       - run: BS_PLAYGROUND=../../main/bundle ./scripts/repl.js -prepublish
         working-directory: bucklescript
 


### PR DESCRIPTION
Ports the basics of the `playground.yml` action in original BuckleScript repo to this one.

The action pulls both repos:
- this one in the `main` folder`
- and bucklescript's one in `bucklescript` folder

then proceeds with the scripts to build ocaml fork, build bucklescript and repl.js.

**Note:** ~the `jsoo_refmt_main.ml` was broken upstream, so the action depends on a custom branch until https://github.com/BuckleScript/bucklescript/pull/4395 is merged.~  Edit: updated to point to master.